### PR TITLE
Fix 'Release' typo.

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -3327,7 +3327,7 @@ exports.download = download;
  */
 function getlatestRelease(repoPath, token) {
     return __awaiter(this, void 0, void 0, function* () {
-        core.info(`Fetching latest relase for repo ${repoPath}`);
+        core.info(`Fetching latest release for repo ${repoPath}`);
         const headers = { Accept: "application/vnd.github.v3+json" };
         if (token !== "") {
             headers["Authorization"] = `token ${token}`;
@@ -3349,7 +3349,7 @@ function getlatestRelease(repoPath, token) {
  */
 function getReleaseByTag(repoPath, tag, token) {
     return __awaiter(this, void 0, void 0, function* () {
-        core.info(`Fetching relase ${tag} from repo ${repoPath}`);
+        core.info(`Fetching release ${tag} from repo ${repoPath}`);
         if (tag === "") {
             throw new Error("Config error: Please input a valid tag");
         }

--- a/src/download.ts
+++ b/src/download.ts
@@ -48,7 +48,7 @@ async function getlatestRelease(
   repoPath: string,
   token: string
 ): Promise<GithubRelease> {
-  core.info(`Fetching latest relase for repo ${repoPath}`)
+  core.info(`Fetching latest release for repo ${repoPath}`)
 
   const headers: IHeaders = {Accept: "application/vnd.github.v3+json"}
   if (token !== "") {
@@ -83,7 +83,7 @@ async function getReleaseByTag(
   tag: string,
   token: string
 ): Promise<GithubRelease> {
-  core.info(`Fetching relase ${tag} from repo ${repoPath}`)
+  core.info(`Fetching release ${tag} from repo ${repoPath}`)
 
   if (tag === "") {
     throw new Error("Config error: Please input a valid tag")


### PR DESCRIPTION
While I was using this action in my workflows, I've noticed that the word 'Release' was misspelled on the output.
![image](https://user-images.githubusercontent.com/34987841/123678365-bd8e0680-d835-11eb-8d6d-720c832767be.png)  
This PR changes 'relase' to 'release'.