### PR TITLE
Change option for downloading all assets to fileName with "*"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,4 +41,17 @@ jobs:
           unzip course-management-tools.zip
           
     - name: List working directory
-      run: ls -lrth      
+      run: ls -lrth
+
+    - name: Test download from a private repo
+      uses: ./
+      with:
+        repository: "robinraju/release-downloader-test"
+        latest: true
+        fileName: "*"
+        tarBall: true
+        zipBall: true
+        token: ${{ secrets.RELEASE_DOWNLOADER_TEST_TOKEN }}
+
+    - name: List working directory
+      run: ls -lrth

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,13 +35,10 @@ jobs:
         repository: "eloots/course-management-tools"
         tag: "1.0.0"
         fileName: "course-management-tools.zip"
-        out-file-path: "."
-    
-    - run: |
-          unzip course-management-tools.zip
+        out-file-path: "./cmt"
           
-    - name: List working directory
-      run: ls -lrth
+    - name: List downloaded files
+      run: ls -lrth cmt
 
     - name: Test download from a private repo
       uses: ./
@@ -52,6 +49,7 @@ jobs:
         tarBall: true
         zipBall: true
         token: ${{ secrets.RELEASE_DOWNLOADER_TEST_TOKEN }}
+        out-file-path: "./downloader-test"
 
-    - name: List working directory
-      run: ls -lrth
+    - name: List downloaded files from private repo
+      run: ls -lrth downloader-test

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ A Github Action to download assets from github release. It can download specifie
     
     # The name of the file to download.
     # Use this field only to specify filenames other than tarball or zipball, if any.
+    # Use '*' to download all assets
     fileName: ""
     
     # Download the attached tarball (*.tar.gz)
@@ -91,4 +92,14 @@ A Github Action to download assets from github release. It can download specifie
     fileName: "foo.zip"
     tarBall: true
     zipBall: true
+```
+
+### Download all assets if more than one files are available
+
+```yaml
+- uses: robinraju/release-downloader@v1.1
+  with:
+    repository: "user/repo"
+    latest: true
+    fileName: "*"
 ```

--- a/action.yml
+++ b/action.yml
@@ -15,7 +15,7 @@ inputs:
     default: ""
     required: false
   fileName:
-    description: "Name of the file to download (if empty it will download all assets)"
+    description: "Name of the file to download (use '*' to download all assets other than tarball or zipball)"
     default: ""
     required: false
   tarBall:

--- a/src/download.ts
+++ b/src/download.ts
@@ -119,7 +119,7 @@ function resolveAssets(
   const downloads: DownloadMetaData[] = []
 
   if (_release && _release.assets.length > 0) {
-    if (_settings.fileName.length === 0) {
+    if (_settings.fileName === "*") {
       // Download all assets
       for (const asset of _release.assets) {
         const dData: DownloadMetaData = {
@@ -129,7 +129,7 @@ function resolveAssets(
         }
         downloads.push(dData)
       }
-    } else if (_settings.fileName.length > 0) {
+    } else {
       const asset = _release.assets.find(a => a.name === _settings.fileName)
       if (asset) {
         const dData: DownloadMetaData = {


### PR DESCRIPTION
To download all assets other than zip ball and tarball, the new syntax is to use fileName as "*"

```yaml
- uses: robinraju/release-downloader@v1.1
  with:
    repository: "user/repo"
    latest: true
    fileName: "*"
```