### PR TITLE
Add GITHUB_TOKEN as the default to prevent rate limit on macOS runner

### DIFF
--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -1,7 +1,9 @@
-import {download} from "../src/download"
 import {IReleaseDownloadSettings} from "../src/download-settings"
+import {download} from "../src/download"
 
 test("run download", async () => {
+  
+  const githubtoken = process.env.GITHUB_TOKEN ?? ""
   const downloadSettings: IReleaseDownloadSettings = {
     sourceRepoPath: "lihaoyi/Ammonite",
     isLatest: false,
@@ -10,7 +12,7 @@ test("run download", async () => {
     tarBall: false,
     zipBall: false,
     outFilePath: "./target",
-    token: ""
+    token: githubtoken
   }
   await download(downloadSettings)
 }, 10000)

--- a/action.yml
+++ b/action.yml
@@ -32,7 +32,7 @@ inputs:
     required: true
   token:
     description: "Github token to access private repos"
-    default: ""
+    default: ${{ github.token }}
     required: false
 runs:
   using: "node16"


### PR DESCRIPTION
Tries to fix #439 

- Enable automatic token authentication using the `GITHUB_TOKEN`
This fixes the rate-limiting enforced by GH API on unauthenticated requests. 