### PR TITLE
Fix test failure on windows runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,8 @@ jobs:
         node-version: 16
         cache: 'npm'
 
-    - name: Build and test  
+    - name: Build and test 
+      shell: bash
       run: |
         npm ci
         npm run all

--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -6,12 +6,11 @@ import * as thc from "typed-rest-client/HttpClient"
 
 import {IReleaseDownloadSettings} from "../src/download-settings"
 import {ReleaseDownloader} from "../src/release-downloader"
-
-const nock = require("nock")
+import nock from "nock"
 
 let downloader: ReleaseDownloader
 let httpClent: thc.HttpClient
-const outputFilePath = "./target"
+const outputFilePath = "./test-output"
 
 beforeEach(() => {
   const githubtoken = process.env.REPO_TOKEN || ""
@@ -64,8 +63,8 @@ beforeEach(() => {
     .replyWithFile(200, __dirname + "/resource/assets/file_example.csv")
 })
 
-afterEach(() => {
-  io.rmRF(outputFilePath)
+afterEach(async () => {
+  await io.rmRF(outputFilePath)
 })
 
 function readFromFile(fileName: string): string {
@@ -141,7 +140,6 @@ test("Download multiple pdf files with wildcard filename", async () => {
     outFilePath: outputFilePath
   }
   const result = await downloader.download(downloadSettings)
-  core.info(`Result from download: ${result}`)
   expect(result.length).toBe(2)
 }, 10000)
 
@@ -156,6 +154,5 @@ test("Download a csv file with wildcard filename", async () => {
     outFilePath: outputFilePath
   }
   const result = await downloader.download(downloadSettings)
-  core.info(`Result from download: ${result}`)
   expect(result.length).toBe(1)
 }, 10000)


### PR DESCRIPTION
Windows runner uses `powershell` as the default shell for a `run` step in the workflow.
Explicitly set it to `bash` so that it will use the bash shell that comes with the git for windows.