### PR TITLE
Fail loudly if an asset is missing from the release

### DIFF
--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -112,6 +112,22 @@ test("Download single file from public repo", async () => {
   expect(result.length).toBe(1)
 }, 10000)
 
+test("Fail loudly if given filename is not found in a release", async () => {
+  const downloadSettings: IReleaseDownloadSettings = {
+    sourceRepoPath: "robinraju/probable-potato",
+    isLatest: true,
+    tag: "",
+    fileName: "missing-file.txt",
+    tarBall: false,
+    zipBall: false,
+    outFilePath: outputFilePath
+  }
+  const result = downloader.download(downloadSettings)
+  await expect(result).rejects.toThrow(
+    "Asset with name missing-file.txt not found!"
+  )
+}, 10000)
+
 test("Download files with wildcard from public repo", async () => {
   const downloadSettings: IReleaseDownloadSettings = {
     sourceRepoPath: "robinraju/probable-potato",

--- a/dist/index.js
+++ b/dist/index.js
@@ -266,6 +266,9 @@ class ReleaseDownloader {
                     };
                     downloads.push(dData);
                 }
+                else {
+                    throw new Error(`Asset with name ${downloadSettings.fileName} not found!`);
+                }
             }
         }
         if (downloadSettings.tarBall) {

--- a/src/release-downloader.ts
+++ b/src/release-downloader.ts
@@ -148,6 +148,10 @@ export class ReleaseDownloader {
             isTarBallOrZipBall: false
           }
           downloads.push(dData)
+        } else {
+          throw new Error(
+            `Asset with name ${downloadSettings.fileName} not found!`
+          )
         }
       }
     }


### PR DESCRIPTION
Fixes #535 