### PR TITLE
[CI] Deprecate old `set-output`method

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -615,7 +615,7 @@ function setOutput(name, value) {
         return file_command_1.issueFileCommand('OUTPUT', file_command_1.prepareKeyValueMessage(name, value));
     }
     process.stdout.write(os.EOL);
-    command_1.issueCommand('set-output', { name }, utils_1.toCommandValue(value));
+    command_1.issue('echo "', { name }, '"="', utils_1.toCommandValue(value),'" >> $GITHUB_OUTPUT');
 }
 exports.setOutput = setOutput;
 /**


### PR DESCRIPTION
Replaced `set-output` method, which will be sooner deprecated, with the new syntax `echo "{name}={value}" >> $GITHUB_OUTPUT`.

More info available [here](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)