### PR TITLE
Dependency updates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,17 +15,17 @@
       },
       "devDependencies": {
         "@types/jest": "^27.4.1",
-        "@types/node": "^18.11.10",
-        "@typescript-eslint/parser": "^5.45.1",
-        "@vercel/ncc": "^0.34.0",
+        "@types/node": "^18.11.17",
+        "@typescript-eslint/parser": "^5.47.0",
+        "@vercel/ncc": "^0.36.0",
         "eslint": "^8.29.0",
         "eslint-plugin-github": "^4.4.1",
-        "eslint-plugin-jest": "^27.1.2",
+        "eslint-plugin-jest": "^27.1.7",
         "jest": "^27.5.1",
         "jest-circus": "^29.3.1",
         "js-yaml": "^4.1.0",
         "nock": "^13.2.9",
-        "prettier": "2.7.1",
+        "prettier": "2.8.1",
         "ts-jest": "^27.1.4",
         "typescript": "^4.8.4"
       }
@@ -1672,9 +1672,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "18.11.11",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.11.tgz",
-      "integrity": "sha512-KJ021B1nlQUBLopzZmPBVuGU9un7WJd/W4ya7Ih02B4Uwky5Nja0yGYav2EfYIk0RR2Q9oVhf60S2XR1BCWJ2g==",
+      "version": "18.11.17",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.17.tgz",
+      "integrity": "sha512-HJSUJmni4BeDHhfzn6nF0sVmd1SMezP7/4F0Lq+aXzmp2xm9O7WXrUtHW/CHlYVtZUbByEvWidHqRtcJXGF2Ng==",
       "dev": true
     },
     "node_modules/@types/prettier": {
@@ -1761,14 +1761,14 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "5.45.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.45.1.tgz",
-      "integrity": "sha512-JQ3Ep8bEOXu16q0ztsatp/iQfDCtvap7sp/DKo7DWltUquj5AfCOpX2zSzJ8YkAVnrQNqQ5R62PBz2UtrfmCkA==",
+      "version": "5.47.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.47.0.tgz",
+      "integrity": "sha512-udPU4ckK+R1JWCGdQC4Qa27NtBg7w020ffHqGyAK8pAgOVuNw7YaKXGChk+udh+iiGIJf6/E/0xhVXyPAbsczw==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "5.45.1",
-        "@typescript-eslint/types": "5.45.1",
-        "@typescript-eslint/typescript-estree": "5.45.1",
+        "@typescript-eslint/scope-manager": "5.47.0",
+        "@typescript-eslint/types": "5.47.0",
+        "@typescript-eslint/typescript-estree": "5.47.0",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -1788,13 +1788,13 @@
       }
     },
     "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/scope-manager": {
-      "version": "5.45.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.45.1.tgz",
-      "integrity": "sha512-D6fCileR6Iai7E35Eb4Kp+k0iW7F1wxXYrOhX/3dywsOJpJAQ20Fwgcf+P/TDtvQ7zcsWsrJaglaQWDhOMsspQ==",
+      "version": "5.47.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.47.0.tgz",
+      "integrity": "sha512-dvJab4bFf7JVvjPuh3sfBUWsiD73aiftKBpWSfi3sUkysDQ4W8x+ZcFpNp7Kgv0weldhpmMOZBjx1wKN8uWvAw==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.45.1",
-        "@typescript-eslint/visitor-keys": "5.45.1"
+        "@typescript-eslint/types": "5.47.0",
+        "@typescript-eslint/visitor-keys": "5.47.0"
       },
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -1805,9 +1805,9 @@
       }
     },
     "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/types": {
-      "version": "5.45.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.45.1.tgz",
-      "integrity": "sha512-HEW3U0E5dLjUT+nk7b4lLbOherS1U4ap+b9pfu2oGsW3oPu7genRaY9dDv3nMczC1rbnRY2W/D7SN05wYoGImg==",
+      "version": "5.47.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.47.0.tgz",
+      "integrity": "sha512-eslFG0Qy8wpGzDdYKu58CEr3WLkjwC5Usa6XbuV89ce/yN5RITLe1O8e+WFEuxnfftHiJImkkOBADj58ahRxSg==",
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -1818,13 +1818,13 @@
       }
     },
     "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/typescript-estree": {
-      "version": "5.45.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.45.1.tgz",
-      "integrity": "sha512-76NZpmpCzWVrrb0XmYEpbwOz/FENBi+5W7ipVXAsG3OoFrQKJMiaqsBMbvGRyLtPotGqUfcY7Ur8j0dksDJDng==",
+      "version": "5.47.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.47.0.tgz",
+      "integrity": "sha512-LxfKCG4bsRGq60Sqqu+34QT5qT2TEAHvSCCJ321uBWywgE2dS0LKcu5u+3sMGo+Vy9UmLOhdTw5JHzePV/1y4Q==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.45.1",
-        "@typescript-eslint/visitor-keys": "5.45.1",
+        "@typescript-eslint/types": "5.47.0",
+        "@typescript-eslint/visitor-keys": "5.47.0",
         "debug": "^4.3.4",
         "globby": "^11.1.0",
         "is-glob": "^4.0.3",
@@ -1845,12 +1845,12 @@
       }
     },
     "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/visitor-keys": {
-      "version": "5.45.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.45.1.tgz",
-      "integrity": "sha512-cy9ln+6rmthYWjH9fmx+5FU/JDpjQb586++x2FZlveq7GdGuLLW9a2Jcst2TGekH82bXpfmRNSwP9tyEs6RjvQ==",
+      "version": "5.47.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.47.0.tgz",
+      "integrity": "sha512-ByPi5iMa6QqDXe/GmT/hR6MZtVPi0SqMQPDx15FczCBXJo/7M8T88xReOALAfpBLm+zxpPfmhuEvPb577JRAEg==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.45.1",
+        "@typescript-eslint/types": "5.47.0",
         "eslint-visitor-keys": "^3.3.0"
       },
       "engines": {
@@ -1936,9 +1936,9 @@
       }
     },
     "node_modules/@vercel/ncc": {
-      "version": "0.34.0",
-      "resolved": "https://registry.npmjs.org/@vercel/ncc/-/ncc-0.34.0.tgz",
-      "integrity": "sha512-G9h5ZLBJ/V57Ou9vz5hI8pda/YQX5HQszCs3AmIus3XzsmRn/0Ptic5otD3xVST8QLKk7AMk7AqpsyQGN7MZ9A==",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@vercel/ncc/-/ncc-0.36.0.tgz",
+      "integrity": "sha512-/ZTUJ/ZkRt694k7KJNimgmHjtQcRuVwsST2Z6XfYveQIuBbHR+EqkTc1jfgPkQmMyk/vtpxo3nVxe8CNuau86A==",
       "dev": true,
       "bin": {
         "ncc": "dist/ncc/cli.js"
@@ -3171,9 +3171,9 @@
       "dev": true
     },
     "node_modules/eslint-plugin-jest": {
-      "version": "27.1.3",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-27.1.3.tgz",
-      "integrity": "sha512-7DrIfYRQPa7JQd1Le8G/BJsfYHVUKQdJQ/6vULSp/4NjKZmSMJ/605G2hhScEra++SiH68zPEjLnrO74nHrMLg==",
+      "version": "27.1.7",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-27.1.7.tgz",
+      "integrity": "sha512-0QVzf+og4YI1Qr3UoprkqqhezAZjFffdi62b0IurkCXMqPtRW84/UT4CKsYT80h/D82LA9avjO/80Ou1LdgbaQ==",
       "dev": true,
       "dependencies": {
         "@typescript-eslint/utils": "^5.10.0"
@@ -6487,9 +6487,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.7.1.tgz",
-      "integrity": "sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==",
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.1.tgz",
+      "integrity": "sha512-lqGoSJBQNJidqCHE80vqZJHWHRFoNYsSpP9AjFhlhi9ODCJA541svILes/+/1GM3VaL/abZi7cpFzOpdR9UPKg==",
       "dev": true,
       "bin": {
         "prettier": "bin-prettier.js"
@@ -8935,9 +8935,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "18.11.11",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.11.tgz",
-      "integrity": "sha512-KJ021B1nlQUBLopzZmPBVuGU9un7WJd/W4ya7Ih02B4Uwky5Nja0yGYav2EfYIk0RR2Q9oVhf60S2XR1BCWJ2g==",
+      "version": "18.11.17",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.17.tgz",
+      "integrity": "sha512-HJSUJmni4BeDHhfzn6nF0sVmd1SMezP7/4F0Lq+aXzmp2xm9O7WXrUtHW/CHlYVtZUbByEvWidHqRtcJXGF2Ng==",
       "dev": true
     },
     "@types/prettier": {
@@ -8998,41 +8998,41 @@
       }
     },
     "@typescript-eslint/parser": {
-      "version": "5.45.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.45.1.tgz",
-      "integrity": "sha512-JQ3Ep8bEOXu16q0ztsatp/iQfDCtvap7sp/DKo7DWltUquj5AfCOpX2zSzJ8YkAVnrQNqQ5R62PBz2UtrfmCkA==",
+      "version": "5.47.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.47.0.tgz",
+      "integrity": "sha512-udPU4ckK+R1JWCGdQC4Qa27NtBg7w020ffHqGyAK8pAgOVuNw7YaKXGChk+udh+iiGIJf6/E/0xhVXyPAbsczw==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/scope-manager": "5.45.1",
-        "@typescript-eslint/types": "5.45.1",
-        "@typescript-eslint/typescript-estree": "5.45.1",
+        "@typescript-eslint/scope-manager": "5.47.0",
+        "@typescript-eslint/types": "5.47.0",
+        "@typescript-eslint/typescript-estree": "5.47.0",
         "debug": "^4.3.4"
       },
       "dependencies": {
         "@typescript-eslint/scope-manager": {
-          "version": "5.45.1",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.45.1.tgz",
-          "integrity": "sha512-D6fCileR6Iai7E35Eb4Kp+k0iW7F1wxXYrOhX/3dywsOJpJAQ20Fwgcf+P/TDtvQ7zcsWsrJaglaQWDhOMsspQ==",
+          "version": "5.47.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.47.0.tgz",
+          "integrity": "sha512-dvJab4bFf7JVvjPuh3sfBUWsiD73aiftKBpWSfi3sUkysDQ4W8x+ZcFpNp7Kgv0weldhpmMOZBjx1wKN8uWvAw==",
           "dev": true,
           "requires": {
-            "@typescript-eslint/types": "5.45.1",
-            "@typescript-eslint/visitor-keys": "5.45.1"
+            "@typescript-eslint/types": "5.47.0",
+            "@typescript-eslint/visitor-keys": "5.47.0"
           }
         },
         "@typescript-eslint/types": {
-          "version": "5.45.1",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.45.1.tgz",
-          "integrity": "sha512-HEW3U0E5dLjUT+nk7b4lLbOherS1U4ap+b9pfu2oGsW3oPu7genRaY9dDv3nMczC1rbnRY2W/D7SN05wYoGImg==",
+          "version": "5.47.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.47.0.tgz",
+          "integrity": "sha512-eslFG0Qy8wpGzDdYKu58CEr3WLkjwC5Usa6XbuV89ce/yN5RITLe1O8e+WFEuxnfftHiJImkkOBADj58ahRxSg==",
           "dev": true
         },
         "@typescript-eslint/typescript-estree": {
-          "version": "5.45.1",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.45.1.tgz",
-          "integrity": "sha512-76NZpmpCzWVrrb0XmYEpbwOz/FENBi+5W7ipVXAsG3OoFrQKJMiaqsBMbvGRyLtPotGqUfcY7Ur8j0dksDJDng==",
+          "version": "5.47.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.47.0.tgz",
+          "integrity": "sha512-LxfKCG4bsRGq60Sqqu+34QT5qT2TEAHvSCCJ321uBWywgE2dS0LKcu5u+3sMGo+Vy9UmLOhdTw5JHzePV/1y4Q==",
           "dev": true,
           "requires": {
-            "@typescript-eslint/types": "5.45.1",
-            "@typescript-eslint/visitor-keys": "5.45.1",
+            "@typescript-eslint/types": "5.47.0",
+            "@typescript-eslint/visitor-keys": "5.47.0",
             "debug": "^4.3.4",
             "globby": "^11.1.0",
             "is-glob": "^4.0.3",
@@ -9041,12 +9041,12 @@
           }
         },
         "@typescript-eslint/visitor-keys": {
-          "version": "5.45.1",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.45.1.tgz",
-          "integrity": "sha512-cy9ln+6rmthYWjH9fmx+5FU/JDpjQb586++x2FZlveq7GdGuLLW9a2Jcst2TGekH82bXpfmRNSwP9tyEs6RjvQ==",
+          "version": "5.47.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.47.0.tgz",
+          "integrity": "sha512-ByPi5iMa6QqDXe/GmT/hR6MZtVPi0SqMQPDx15FczCBXJo/7M8T88xReOALAfpBLm+zxpPfmhuEvPb577JRAEg==",
           "dev": true,
           "requires": {
-            "@typescript-eslint/types": "5.45.1",
+            "@typescript-eslint/types": "5.47.0",
             "eslint-visitor-keys": "^3.3.0"
           }
         }
@@ -9094,9 +9094,9 @@
       }
     },
     "@vercel/ncc": {
-      "version": "0.34.0",
-      "resolved": "https://registry.npmjs.org/@vercel/ncc/-/ncc-0.34.0.tgz",
-      "integrity": "sha512-G9h5ZLBJ/V57Ou9vz5hI8pda/YQX5HQszCs3AmIus3XzsmRn/0Ptic5otD3xVST8QLKk7AMk7AqpsyQGN7MZ9A==",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@vercel/ncc/-/ncc-0.36.0.tgz",
+      "integrity": "sha512-/ZTUJ/ZkRt694k7KJNimgmHjtQcRuVwsST2Z6XfYveQIuBbHR+EqkTc1jfgPkQmMyk/vtpxo3nVxe8CNuau86A==",
       "dev": true
     },
     "abab": {
@@ -10109,9 +10109,9 @@
       }
     },
     "eslint-plugin-jest": {
-      "version": "27.1.3",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-27.1.3.tgz",
-      "integrity": "sha512-7DrIfYRQPa7JQd1Le8G/BJsfYHVUKQdJQ/6vULSp/4NjKZmSMJ/605G2hhScEra++SiH68zPEjLnrO74nHrMLg==",
+      "version": "27.1.7",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-27.1.7.tgz",
+      "integrity": "sha512-0QVzf+og4YI1Qr3UoprkqqhezAZjFffdi62b0IurkCXMqPtRW84/UT4CKsYT80h/D82LA9avjO/80Ou1LdgbaQ==",
       "dev": true,
       "requires": {
         "@typescript-eslint/utils": "^5.10.0"
@@ -12534,9 +12534,9 @@
       "dev": true
     },
     "prettier": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.7.1.tgz",
-      "integrity": "sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==",
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.1.tgz",
+      "integrity": "sha512-lqGoSJBQNJidqCHE80vqZJHWHRFoNYsSpP9AjFhlhi9ODCJA541svILes/+/1GM3VaL/abZi7cpFzOpdR9UPKg==",
       "dev": true
     },
     "prettier-linter-helpers": {

--- a/package.json
+++ b/package.json
@@ -32,17 +32,17 @@
   },
   "devDependencies": {
     "@types/jest": "^27.4.1",
-    "@types/node": "^18.11.10",
-    "@typescript-eslint/parser": "^5.45.1",
-    "@vercel/ncc": "^0.34.0",
+    "@types/node": "^18.11.17",
+    "@typescript-eslint/parser": "^5.47.0",
+    "@vercel/ncc": "^0.36.0",
     "eslint": "^8.29.0",
     "eslint-plugin-github": "^4.4.1",
-    "eslint-plugin-jest": "^27.1.2",
+    "eslint-plugin-jest": "^27.1.7",
     "jest": "^27.5.1",
     "jest-circus": "^29.3.1",
     "js-yaml": "^4.1.0",
     "nock": "^13.2.9",
-    "prettier": "2.7.1",
+    "prettier": "2.8.1",
     "ts-jest": "^27.1.4",
     "typescript": "^4.8.4"
   }


### PR DESCRIPTION

Bump eslint-plugin-jest from 27.1.3 to 27.1.7
Bump @types/node from 18.11.11 to 18.11.17
Bump @typescript-eslint/parser from 5.45.1 to 5.47.0 Bump prettier from 2.7.1 to 2.8.1
Bump @vercel/ncc from 0.34.0 to 0.36.0