### PR TITLE
[Release management] -  Move the major version tag (such as v1, v2) to point to the Git ref of the current release.

### DIFF
--- a/.github/workflows/update-main-version.yml
+++ b/.github/workflows/update-main-version.yml
@@ -1,0 +1,34 @@
+# This workflow is used to move the major version tag (such as v1, v2) 
+# to point to the Git ref of the current release.
+# This allows users to use the latest version of this action by specifying the major version.
+
+name: Update Main Version
+run-name: Move ${{ github.event.inputs.major_version }} to ${{ github.event.inputs.target }}
+
+on:
+  workflow_dispatch:
+    inputs:
+      target:
+        description: The tag or reference to use
+        required: true
+      major_version:
+        type: choice
+        description: The major version to update
+        options:
+          - v1
+
+jobs:
+  tag:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+    - name: Git config
+      run: |
+        git config user.name "github-actions[bot]"
+        git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+    - name: Tag new target
+      run: git tag -f ${{ github.event.inputs.major_version }} ${{ github.event.inputs.target }}
+    - name: Push new tag
+      run: git push origin ${{ github.event.inputs.major_version }} --force


### PR DESCRIPTION
 #749 