### PR TITLE
fix #729: Remove archive after extraction

### DIFF
--- a/__tests__/unarchive.test.ts
+++ b/__tests__/unarchive.test.ts
@@ -36,8 +36,10 @@ describe('extract', () => {
 
   test('extracts a tar.gz archive into a created destination directory', async () => {
     const destination = path.join(testRoot, 'tar-gz-output')
+    const archivePath = path.join(testRoot, 'tar-zip-ball-only-repo.tar.gz')
+    fs.copyFileSync(fixturePath('tar-zip-ball-only-repo.tar.gz'), archivePath)
 
-    await extract(fixturePath('tar-zip-ball-only-repo.tar.gz'), destination)
+    await extract(archivePath, destination)
 
     expect(fs.existsSync(destination)).toBe(true)
     expect(fs.readdirSync(destination).length).toBeGreaterThan(0)

--- a/src/unarchive.ts
+++ b/src/unarchive.ts
@@ -50,6 +50,15 @@ export const extract = async (
       await zip.extract(null, destDir)
       await zip.close()
     }
+
+    fs.rm(filePath, err => {
+      if (err) {
+        core.warning(
+          `Failed to delete archive ${filename} after extraction: ${err.message}`
+        )
+      }
+    })
+    core.info(`Extracted ${filename} to ${destDir}`)
   } catch (err) {
     // Provide context for extraction failures
     const errMsg = err instanceof Error ? err.message : String(err)
@@ -65,7 +74,4 @@ export const extract = async (
       { filePath, destDir }
     )
   }
-  
-  await fs.rm(filePath)
-  core.info(`Extracted ${filename} to ${destDir}`)
 }


### PR DESCRIPTION
Almost all uses of this action that will be extracting a release archive will not need the archive after the fact, so I opted to not put this behind a flag option.