### PR TITLE
Count .tgz as tar

### DIFF
--- a/src/unarchive.ts
+++ b/src/unarchive.ts
@@ -8,7 +8,7 @@ export const extract = async (
   filePath: string,
   destDir: string
 ): Promise<void> => {
-  const isTarGz = filePath.endsWith('.tar.gz') || filePath.endsWith('.tar')
+  const isTarGz = filePath.endsWith('.tar.gz') || filePath.endsWith('.tar') || filePath.endsWith('.tgz')
   const isZip = filePath.endsWith('.zip')
   const filename = path.basename(filePath)
 


### PR DESCRIPTION
I was trying to download the latest linux release from https://github.com/microsoft/onnxruntime/releases
Because it's a .tgz file not .tar.gz, it fails to download. This is a quick fix to include that extension.