### PR TITLE
Potential fix for code scanning alert no. 8: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/update-main-version.yml
+++ b/.github/workflows/update-main-version.yml
@@ -22,6 +22,8 @@ on:
 jobs:
   tag:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v6
         with:


### PR DESCRIPTION
Potential fix for [https://github.com/robinraju/release-downloader/security/code-scanning/8](https://github.com/robinraju/release-downloader/security/code-scanning/8)

To fix the issue, add an explicit `permissions` block that grants only the scopes this workflow needs. The steps perform a checkout and then create and push a Git tag back to the repository. That requires write access to repository contents, so `contents: write` is necessary; no other permission types (issues, pull-requests, etc.) are used.

The least-privilege, behavior-preserving fix is:

- Add a `permissions` section at the job level under `jobs.tag` (so it only applies to this workflow’s single job).
- Set `contents: write` so that creating and force-pushing the tag continues to work.
- Do not change any existing steps or logic.

Concretely, in `.github/workflows/update-main-version.yml`, under `jobs:`, inside the `tag:` job, add:

```yaml
    permissions:
      contents: write
```

at the same indentation level as `runs-on:`. No additional imports or definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
